### PR TITLE
Dynamic router

### DIFF
--- a/routini/Cargo.lock
+++ b/routini/Cargo.lock
@@ -1905,6 +1905,7 @@ dependencies = [
 name = "routini"
 version = "0.1.0"
 dependencies = [
+ "arc-swap",
  "async-trait",
  "pingora",
  "reqwest",

--- a/routini/Cargo.toml
+++ b/routini/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 async-trait = "0.1.89"
+arc-swap = "1.7.1"
 pingora = { version = "0.6.0", features = [
     "lb",
     "pingora-proxy",

--- a/routini/src/load_balancer.rs
+++ b/routini/src/load_balancer.rs
@@ -1,10 +1,11 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
+use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use pingora::{
     Error, ErrorSource, ErrorType, ImmutStr, Result, RetryType,
     lb::{
-        LoadBalancer,
+        Backend, LoadBalancer,
         selection::{BackendIter, BackendSelection},
     },
     prelude::HttpPeer,
@@ -12,18 +13,93 @@ use pingora::{
 };
 use tracing::instrument;
 
-const MAX_ALGORITHM_ITERATIONS: usize = 256;
+// DEFAULT_MAX_ALGORITHM_ITERATIONS is there to bound the search time for the next Backend. In certain algorithm like Ketama hashing, the search for the next backend is linear and could take a lot of steps.
+pub const DEFAULT_MAX_ALGORITHM_ITERATIONS: usize = 256;
 
-pub struct LB<Algorithm> {
-    pub backends: Arc<LoadBalancer<Algorithm>>,
+pub type StrategyId = String;
+
+/// Trait object wrapper over `LoadBalancer<S>` so we can store different algorithms together.
+pub trait DynLoadBalancer: Send + Sync {
+    fn select(&self, key: &[u8], max_iterations: usize) -> Option<Backend>;
+}
+
+impl<S> DynLoadBalancer for LoadBalancer<S>
+where
+    S: BackendSelection + Send + Sync + 'static,
+    S::Iter: BackendIter,
+{
+    fn select(&self, key: &[u8], max_iterations: usize) -> Option<Backend> {
+        LoadBalancer::select(self, key, max_iterations)
+    }
+}
+
+/// Routing configuration describing the active strategy.
+#[derive(Clone)]
+pub struct RoutingConfig {
+    active: StrategyId,
+}
+
+impl RoutingConfig {
+    pub fn new(active: impl Into<StrategyId>) -> Self {
+        Self {
+            active: active.into(),
+        }
+    }
+
+    pub fn strategy(&self) -> &str {
+        &self.active
+    }
+}
+
+pub struct MultiLoadBalancer {
+    strategies: HashMap<StrategyId, Arc<dyn DynLoadBalancer>>,
+    routing_rules: Arc<ArcSwap<RoutingConfig>>,
+    max_iterations: usize,
+}
+
+#[derive(Clone)]
+pub struct MultiLoadBalancerHandle {
+    routing_rules: Arc<ArcSwap<RoutingConfig>>,
+}
+
+impl MultiLoadBalancerHandle {
+    pub fn update_routing(&self, new_config: RoutingConfig) {
+        self.routing_rules.store(Arc::new(new_config));
+    }
+
+    pub fn load(&self) -> Arc<RoutingConfig> {
+        self.routing_rules.load_full()
+    }
+}
+
+impl MultiLoadBalancer {
+    pub fn new(
+        strategies: HashMap<StrategyId, Arc<dyn DynLoadBalancer>>,
+        initial_config: RoutingConfig,
+        max_iterations: usize,
+    ) -> Self {
+        let default = initial_config.strategy().to_string();
+        assert!(
+            strategies.contains_key(&default),
+            "initial routing config must reference an existing strategy"
+        );
+
+        Self {
+            strategies,
+            routing_rules: Arc::new(ArcSwap::new(Arc::new(initial_config))),
+            max_iterations,
+        }
+    }
+
+    pub fn handle(&self) -> MultiLoadBalancerHandle {
+        MultiLoadBalancerHandle {
+            routing_rules: Arc::clone(&self.routing_rules),
+        }
+    }
 }
 
 #[async_trait]
-impl<A> ProxyHttp for LB<A>
-where
-    A: BackendSelection + 'static + Send + Sync,
-    A::Iter: BackendIter,
-{
+impl ProxyHttp for MultiLoadBalancer {
     type CTX = ();
     fn new_ctx(&self) -> Self::CTX {}
 
@@ -33,16 +109,22 @@ where
         _session: &mut Session,
         _ctx: &mut Self::CTX,
     ) -> Result<Box<HttpPeer>> {
-        let upstream = self
-            .backends
-            .select(&[], MAX_ALGORITHM_ITERATIONS)
-            .ok_or(Error {
-                context: Some(ImmutStr::Static("No healthy backends available")),
-                cause: None,
-                etype: ErrorType::InternalError,
-                esource: ErrorSource::Internal,
-                retry: RetryType::Decided(true),
-            })?;
+        let config = self.routing_rules.load();
+        let strategy_id = config.strategy();
+        let strategy = self.strategies.get(strategy_id).ok_or(Error {
+            context: Some(ImmutStr::Static("Requested strategy not registered")),
+            cause: None,
+            etype: ErrorType::InternalError,
+            esource: ErrorSource::Internal,
+            retry: RetryType::Decided(true),
+        })?;
+        let upstream = strategy.select(&[], self.max_iterations).ok_or(Error {
+            context: Some(ImmutStr::Static("No healthy backends available")),
+            cause: None,
+            etype: ErrorType::InternalError,
+            esource: ErrorSource::Internal,
+            retry: RetryType::Decided(true),
+        })?;
 
         let peer = Box::new(HttpPeer::new(upstream, false, String::new()));
         Ok(peer)

--- a/routini/src/main.rs
+++ b/routini/src/main.rs
@@ -1,5 +1,8 @@
-use pingora::prelude::RoundRobin;
-use routini::{application::Application, utils::tracing::init_tracing};
+use routini::{
+    application::{Application, StrategyConfig, StrategyKind},
+    load_balancer::RoutingConfig,
+    utils::tracing::init_tracing,
+};
 use std::net::TcpListener;
 
 fn main() {
@@ -12,5 +15,13 @@ fn main() {
         "127.0.0.1:4002".to_owned(),
     ];
 
-    Application::<RoundRobin>::new(listener, backends).run();
+    let strategies = vec![
+        StrategyConfig::new("round_robin", StrategyKind::RoundRobin),
+        StrategyConfig::new("random", StrategyKind::Random),
+    ];
+
+    let routing = RoutingConfig::new("round_robin");
+
+    let app = Application::new(listener, backends, strategies, routing);
+    app.run();
 }


### PR DESCRIPTION
**Dynamic Router Overview**

We now spin up a separate Pingora `LoadBalancer<Algo>` for each strategy we care about, keep them warm with their own background services, and route requests through a `MultiLoadBalancer`. The `MultiLoadBalancer` stores these balancers in a `HashMap<StrategyId, Arc<dyn DynLoadBalancer>>`, so we can add/remove algorithms without recompiling. Each request reads a hot-swappable `RoutingConfig` (behind `ArcSwap`) to pick the active strategy and forwards to that balancer’s select.

**Key Trade-offs**

Multiple Balancers + Router

- Pros: 
   - instant strategy switches
   - clean traffic segmentation/A/B testing
   - isolates failures per algorithm
   - reuses Pingora strategies as-is.
- Cons: 
    - more memory/CPU (each balancer keeps its own state and background task)
    - small extra lookup per request
    - slightly more wiring at startup

Single Balancer + Selector Enum

- Pros: 
    - minimal resource footprint
    - no routing indirection
    - only one health-check loop to manage.
- Cons: 
    - you must write a custom selector enum and iterator
    - hard to run multiple strategies concurrently
    - Swapping selector variants can leave stale state behind
    - harder for others to extend

**Control Surface**

`RoutingConfig` is the runtime knob; callers clone the `MultiLoadBalancerHandle` and update routing with a new config.

**Current Scope / Next Steps**

Today `RoutingConfig` only holds a single “active strategy” at a time. When we want per-path or percentage-based routing, we can extend `RoutingConfig` without touching the router or service wiring.