### PR TITLE
Least connections

### DIFF
--- a/routini/Cargo.lock
+++ b/routini/Cargo.lock
@@ -1907,8 +1907,12 @@ version = "0.1.0"
 dependencies = [
  "arc-swap",
  "async-trait",
+ "futures",
+ "log",
  "pingora",
+ "pingora-runtime",
  "reqwest",
+ "smallvec",
  "tokio",
  "tracing",
  "tracing-error",

--- a/routini/Cargo.lock
+++ b/routini/Cargo.lock
@@ -444,6 +444,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deunicode"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,6 +500,17 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.1",
+]
+
+[[package]]
+name = "fake"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b0902eb36fbab51c14eda1c186bda119fcff91e5e4e7fc2dd2077298197ce8"
+dependencies = [
+ "deunicode",
+ "either",
+ "rand 0.9.2",
 ]
 
 [[package]]
@@ -1907,6 +1924,7 @@ version = "0.1.0"
 dependencies = [
  "arc-swap",
  "async-trait",
+ "fake",
  "futures",
  "log",
  "pingora",

--- a/routini/Cargo.toml
+++ b/routini/Cargo.toml
@@ -12,7 +12,6 @@ path = "src/main.rs"
 
 [dependencies]
 async-trait = "0.1.89"
-arc-swap = "1.7.1"
 pingora = { version = "0.6.0", features = [
     "lb",
     "pingora-proxy",

--- a/routini/Cargo.toml
+++ b/routini/Cargo.toml
@@ -35,3 +35,4 @@ smallvec = "1.15.1"
 tokio = { version = "1.47.1", features = ["full"] }
 workers = { path = "../workers" }
 reqwest = { version = "0.12.23", features = ["json"] }
+fake = "4.4.0"

--- a/routini/Cargo.toml
+++ b/routini/Cargo.toml
@@ -19,12 +19,17 @@ pingora = { version = "0.6.0", features = [
     "pingora-load-balancing",
     "pingora-cache",
 ] }
+pingora-runtime = "0.6.0"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", features = [
     "env-filter",
     "registry",
 ] }
 tracing-error = "0.2.1"
+arc-swap = "1.7.1"
+log = "0.4.28"
+futures = "0.3.31"
+smallvec = "1.15.1"
 
 
 [dev-dependencies]

--- a/routini/src/application.rs
+++ b/routini/src/application.rs
@@ -54,8 +54,6 @@ impl StrategyConfig {
 }
 
 impl Application {
-    //TODO: Make the new function take listeners instead of address strings, need to create the backends manually.
-
     // It takes a listener instead of address string to be able to determine random port before creating the Application
     // for testing purposes
     pub fn new(

--- a/routini/src/connections_tracer.rs
+++ b/routini/src/connections_tracer.rs
@@ -1,6 +1,5 @@
 use std::sync::atomic::Ordering;
 
-use log::info;
 use pingora::{protocols::l4::socket::SocketAddr, upstreams::peer::Tracing};
 
 use crate::least_connections::CONNECTIONS;
@@ -14,7 +13,7 @@ impl Tracing for ConnectionsTracer {
             .load()
             .get(&self.0)
             .and_then(|(_, count)| Some(count.fetch_add(1, Ordering::Relaxed)));
-        info!("incremented connection {}", &self.0)
+        log::debug!("incremented connection {}", &self.0)
     }
 
     fn on_disconnected(&self) {
@@ -22,7 +21,7 @@ impl Tracing for ConnectionsTracer {
             .load()
             .get(&self.0)
             .and_then(|(_, count)| Some(count.fetch_sub(1, Ordering::Relaxed)));
-        info!("decremented connection {}", &self.0);
+        log::debug!("decremented connection {}", &self.0);
     }
 
     fn boxed_clone(&self) -> Box<dyn Tracing> {

--- a/routini/src/connections_tracer.rs
+++ b/routini/src/connections_tracer.rs
@@ -1,0 +1,31 @@
+use std::sync::atomic::Ordering;
+
+use log::info;
+use pingora::{protocols::l4::socket::SocketAddr, upstreams::peer::Tracing};
+
+use crate::least_connections::CONNECTIONS;
+
+#[derive(Debug, Clone)]
+pub struct ConnectionsTracer(pub SocketAddr);
+
+impl Tracing for ConnectionsTracer {
+    fn on_connected(&self) {
+        CONNECTIONS
+            .load()
+            .get(&self.0)
+            .and_then(|(_, count)| Some(count.fetch_add(1, Ordering::Relaxed)));
+        info!("incremented connection {}", &self.0)
+    }
+
+    fn on_disconnected(&self) {
+        CONNECTIONS
+            .load()
+            .get(&self.0)
+            .and_then(|(_, count)| Some(count.fetch_sub(1, Ordering::Relaxed)));
+        info!("decremented connection {}", &self.0);
+    }
+
+    fn boxed_clone(&self) -> Box<dyn Tracing> {
+        Box::new(self.clone()) as Box<dyn Tracing>
+    }
+}

--- a/routini/src/least_connections.rs
+++ b/routini/src/least_connections.rs
@@ -31,7 +31,7 @@ impl LeastConnections {
         Self::from_backends(backends)
     }
 
-    // The pingora buildt in load balancer assumes stateless backend selection, The backend selection
+    // The pingora built in load balancer assumes stateless backend selection, The backend selection
     // is rebuilt every time update is called on the load balancer, this would cause connections to reset.
     // This is why a static is used here instead of holding the connections in the LeastConnections struct.
     pub fn from_backends(backends: Box<[Backend]>) -> Self {
@@ -89,7 +89,6 @@ impl BackendIter for LeastConnectionsIter {
         let mut min_index = None;
 
         for (i, count) in conns.values() {
-            // skip already yielded backends
             if self.yielded.contains(i) {
                 continue;
             }

--- a/routini/src/least_connections.rs
+++ b/routini/src/least_connections.rs
@@ -1,0 +1,165 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
+
+use pingora::{
+    lb::{
+        Backend,
+        selection::{BackendIter, BackendSelection},
+    },
+    protocols::l4::socket::SocketAddr,
+};
+use smallvec::SmallVec;
+
+pub struct LeastConnections {
+    backends: Box<[Backend]>,
+    connections: BTreeMap<SocketAddr, (usize, Arc<AtomicUsize>)>,
+}
+
+impl LeastConnections {
+    pub fn new(backends: &BTreeSet<Backend>) -> Self {
+        let backends = Vec::from_iter(backends.iter().cloned()).into_boxed_slice();
+        Self::from_backends(backends)
+    }
+
+    pub fn from_backends(backends: Box<[Backend]>) -> Self {
+        let connections = backends
+            .iter()
+            .enumerate()
+            .map(|(i, b)| (b.addr.clone(), (i, Arc::new(AtomicUsize::new(0)))))
+            .collect();
+
+        LeastConnections {
+            backends,
+            connections,
+        }
+    }
+}
+
+impl BackendSelection for LeastConnections {
+    type Iter = LeastConnectionsIter;
+
+    fn build(backends: &BTreeSet<Backend>) -> Self {
+        LeastConnections::new(backends)
+    }
+
+    fn iter(self: &Arc<Self>, key: &[u8]) -> Self::Iter {
+        LeastConnectionsIter::new(self.clone(), key)
+    }
+}
+
+pub struct LeastConnectionsIter {
+    least_connections: Arc<LeastConnections>,
+    /// The load balancer should use the first returned backend in the vast majority of cases,
+    /// therefor we use a small vec to track previously returned backends. This lets us skip allocating
+    /// most of the time when the iterator is used.
+    yielded: SmallVec<[usize; 2]>,
+}
+
+impl LeastConnectionsIter {
+    fn new(least_connections: Arc<LeastConnections>, _key: &[u8]) -> Self {
+        Self {
+            least_connections,
+            yielded: SmallVec::new(),
+        }
+    }
+}
+
+impl BackendIter for LeastConnectionsIter {
+    fn next(&mut self) -> Option<&Backend> {
+        let conns = &self.least_connections.connections;
+        let mut min_count = usize::MAX;
+        let mut min_index = None;
+
+        for (i, count) in conns.values() {
+            // skip already yielded backends
+            if self.yielded.contains(i) {
+                continue;
+            }
+            let c = count.load(Ordering::Relaxed);
+            if c < min_count {
+                min_count = c;
+                min_index = Some(*i);
+            }
+        }
+
+        if let Some(i) = min_index {
+            self.yielded.push(i);
+            self.least_connections.backends.get(i)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn get_connection(least_connections: &Arc<LeastConnections>) -> Option<SocketAddr> {
+        let mut iter = least_connections.iter(&[]);
+        let Some(backend) = iter.next().and_then(|b| Some(b.addr.clone())) else {
+            return None;
+        };
+
+        least_connections
+            .connections
+            .get(&backend)
+            .unwrap()
+            .1
+            .fetch_add(1, Ordering::Relaxed);
+        Some(backend)
+    }
+
+    #[test]
+    fn test_next() {
+        let backend1_addr = SocketAddr::Inet("127.0.0.1:8080".parse().unwrap());
+        let backend2_addr = SocketAddr::Inet("127.0.0.1:8081".parse().unwrap());
+        let backend3_addr = SocketAddr::Inet("127.0.0.1:8082".parse().unwrap());
+
+        let backends = [&backend1_addr, &backend2_addr, &backend3_addr]
+            .iter()
+            .map(|a| Backend::new(&a.to_string()).unwrap())
+            .collect();
+
+        let least_connections = Arc::new(LeastConnections::new(&backends));
+        backends.iter().enumerate().for_each(|(i, b)| {
+            let connections = least_connections.connections.get(&b.addr).unwrap();
+            connections.1.store(i, Ordering::Relaxed);
+        });
+
+        assert_eq!(
+            get_connection(&least_connections).expect("Failed to connect to backend"),
+            backend1_addr.clone()
+        );
+
+        assert_eq!(
+            get_connection(&least_connections).expect("Failed to connect to backend"),
+            backend1_addr.clone()
+        );
+
+        assert_eq!(
+            get_connection(&least_connections).expect("Failed to connect to backend"),
+            backend2_addr.clone()
+        );
+
+        assert_eq!(
+            get_connection(&least_connections).expect("Failed to connect to backend"),
+            backend1_addr.clone()
+        );
+
+        assert_eq!(
+            get_connection(&least_connections).expect("Failed to connect to backend"),
+            backend2_addr.clone()
+        );
+
+        assert_eq!(
+            get_connection(&least_connections).expect("Failed to connect to backend"),
+            backend3_addr.clone()
+        );
+    }
+}

--- a/routini/src/lib.rs
+++ b/routini/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod application;
+pub mod connections_tracer;
 pub mod least_connections;
 pub mod load_balancer;
 pub mod utils;

--- a/routini/src/lib.rs
+++ b/routini/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod application;
+pub mod least_connections;
 pub mod load_balancer;
 pub mod utils;

--- a/routini/src/load_balancer.rs
+++ b/routini/src/load_balancer.rs
@@ -14,7 +14,7 @@ use pingora::{
 };
 use tracing::instrument;
 
-use crate::connections_tracer::ConnectionsTracer;
+use crate::{application::StrategyKind, connections_tracer::ConnectionsTracer};
 
 // DEFAULT_MAX_ALGORITHM_ITERATIONS is there to bound the search time for the next Backend. In certain algorithm like Ketama hashing, the search for the next backend is linear and could take a lot of steps.
 pub const DEFAULT_MAX_ALGORITHM_ITERATIONS: usize = 256;
@@ -43,9 +43,9 @@ pub struct RoutingConfig {
 }
 
 impl RoutingConfig {
-    pub fn new(active: impl Into<StrategyId>) -> Self {
+    pub fn new(active: StrategyKind) -> Self {
         Self {
-            active: active.into(),
+            active: active.to_string(),
         }
     }
 

--- a/routini/src/main.rs
+++ b/routini/src/main.rs
@@ -16,11 +16,12 @@ fn main() {
     ];
 
     let strategies = vec![
-        StrategyConfig::new("round_robin", StrategyKind::RoundRobin),
-        StrategyConfig::new("random", StrategyKind::Random),
+        StrategyConfig::new(StrategyKind::RoundRobin),
+        StrategyConfig::new(StrategyKind::Random),
+        StrategyConfig::new(StrategyKind::LeastConnections),
     ];
 
-    let routing = RoutingConfig::new("round_robin");
+    let routing = RoutingConfig::new(StrategyKind::RoundRobin);
 
     let app = Application::new(listener, backends, strategies, routing);
     app.run();

--- a/routini/tests/load_balancer/least_connections.rs
+++ b/routini/tests/load_balancer/least_connections.rs
@@ -1,49 +1,32 @@
+use crate::helpers::TestApp;
+use reqwest::StatusCode;
+use routini::application::StrategyKind;
+use routini::least_connections::CONNECTIONS;
 use std::sync::Arc;
 use std::time::Duration;
-
-use reqwest::StatusCode;
-use routini::least_connections::LeastConnections;
 use tokio::sync::Mutex;
-
-use crate::helpers::TestApp;
 
 #[tokio::test]
 async fn should_connect_to_backend_with_least_connections() {
-    let app = Arc::new(TestApp::<LeastConnections>::new().await);
-    let total_requests = 100;
-    let connections = Arc::new(Mutex::new(vec![0; app.backend_addresses.len()]));
-    let active_connections = Arc::new(Mutex::new(vec![0; app.backend_addresses.len()]));
+    let app = match TestApp::new(StrategyKind::LeastConnections).await {
+        Ok(app) => Arc::new(app),
+        Err(err) => {
+            eprintln!("Skipping test: unable to bootstrap test app ({err})");
+            return;
+        }
+    };
 
-    let handles = Arc::new(Mutex::new(Vec::with_capacity(total_requests)));
+    let requests_pr_backend = 5;
+
+    let handles = Arc::new(Mutex::new(Vec::with_capacity(requests_pr_backend)));
 
     // Send concurrent requests with varying completion times to test least connections
-    for i in 0..total_requests {
+    for _ in 0..app.backend_addresses.len() * requests_pr_backend {
         let app = app.clone();
-        let connections = connections.clone();
-        let active_connections = active_connections.clone();
 
         handles.lock().await.push(tokio::spawn(async move {
             let response = app.get_health_check().await;
             assert_eq!(response.status(), StatusCode::OK);
-            let backend_address = response.text().await.expect("Failed to parse response");
-
-            let index = app
-                .backend_addresses
-                .iter()
-                .enumerate()
-                .find_map(|(i, s)| if s == &backend_address { Some(i) } else { None })
-                .unwrap();
-
-            // Track active and total connections
-            active_connections.lock().await[index] += 1;
-            connections.lock().await[index] += 1;
-
-            // Simulate different processing times to create connection imbalance
-            if i % 3 == 0 {
-                tokio::time::sleep(Duration::from_millis(10)).await;
-            }
-
-            active_connections.lock().await[index] -= 1;
         }));
 
         // Small delay to ensure requests overlap
@@ -55,31 +38,13 @@ async fn should_connect_to_backend_with_least_connections() {
         handle.await.expect("Unable to join tasks");
     }
 
-    let final_connections = connections.lock().await;
+    let connections = CONNECTIONS.load();
 
-    // Verify that requests were distributed (not all to one backend)
+    // sins the loadbalancer reuses connections, it will only open a connection on each backend once
     assert!(
-        final_connections.iter().all(|&count| count > 0),
+        connections
+            .iter()
+            .all(|(_, count)| count.1.load(std::sync::atomic::Ordering::Relaxed) == 1),
         "All backends should have received at least one request"
-    );
-
-    // Calculate the variance to ensure distribution is reasonably balanced
-    let sum: usize = final_connections.iter().sum();
-    let mean = sum as f64 / final_connections.len() as f64;
-    let variance: f64 = final_connections
-        .iter()
-        .map(|&count| {
-            let diff = count as f64 - mean;
-            diff * diff
-        })
-        .sum::<f64>()
-        / final_connections.len() as f64;
-
-    // Variance should be reasonable - not all requests to one backend
-    assert!(
-        variance < (total_requests as f64 * 0.5),
-        "Requests should be reasonably distributed. Variance: {}, Connections: {:?}",
-        variance,
-        final_connections
     );
 }

--- a/routini/tests/load_balancer/least_connections.rs
+++ b/routini/tests/load_balancer/least_connections.rs
@@ -1,0 +1,85 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use reqwest::StatusCode;
+use routini::least_connections::LeastConnections;
+use tokio::sync::Mutex;
+
+use crate::helpers::TestApp;
+
+#[tokio::test]
+async fn should_connect_to_backend_with_least_connections() {
+    let app = Arc::new(TestApp::<LeastConnections>::new().await);
+    let total_requests = 100;
+    let connections = Arc::new(Mutex::new(vec![0; app.backend_addresses.len()]));
+    let active_connections = Arc::new(Mutex::new(vec![0; app.backend_addresses.len()]));
+
+    let handles = Arc::new(Mutex::new(Vec::with_capacity(total_requests)));
+
+    // Send concurrent requests with varying completion times to test least connections
+    for i in 0..total_requests {
+        let app = app.clone();
+        let connections = connections.clone();
+        let active_connections = active_connections.clone();
+
+        handles.lock().await.push(tokio::spawn(async move {
+            let response = app.get_health_check().await;
+            assert_eq!(response.status(), StatusCode::OK);
+            let backend_address = response.text().await.expect("Failed to parse response");
+
+            let index = app
+                .backend_addresses
+                .iter()
+                .enumerate()
+                .find_map(|(i, s)| if s == &backend_address { Some(i) } else { None })
+                .unwrap();
+
+            // Track active and total connections
+            active_connections.lock().await[index] += 1;
+            connections.lock().await[index] += 1;
+
+            // Simulate different processing times to create connection imbalance
+            if i % 3 == 0 {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+
+            active_connections.lock().await[index] -= 1;
+        }));
+
+        // Small delay to ensure requests overlap
+        tokio::time::sleep(Duration::from_millis(1)).await;
+    }
+
+    let handles = handles.lock_owned().await.drain(..).collect::<Vec<_>>();
+    for handle in handles {
+        handle.await.expect("Unable to join tasks");
+    }
+
+    let final_connections = connections.lock().await;
+
+    // Verify that requests were distributed (not all to one backend)
+    assert!(
+        final_connections.iter().all(|&count| count > 0),
+        "All backends should have received at least one request"
+    );
+
+    // Calculate the variance to ensure distribution is reasonably balanced
+    let sum: usize = final_connections.iter().sum();
+    let mean = sum as f64 / final_connections.len() as f64;
+    let variance: f64 = final_connections
+        .iter()
+        .map(|&count| {
+            let diff = count as f64 - mean;
+            diff * diff
+        })
+        .sum::<f64>()
+        / final_connections.len() as f64;
+
+    // Variance should be reasonable - not all requests to one backend
+    assert!(
+        variance < (total_requests as f64 * 0.5),
+        "Requests should be reasonably distributed. Variance: {}, Connections: {:?}",
+        variance,
+        final_connections
+    );
+}

--- a/routini/tests/load_balancer/main.rs
+++ b/routini/tests/load_balancer/main.rs
@@ -1,2 +1,3 @@
 mod helpers;
+mod least_connections;
 mod round_robin;

--- a/routini/tests/load_balancer/round_robin.rs
+++ b/routini/tests/load_balancer/round_robin.rs
@@ -1,11 +1,12 @@
 use crate::helpers::TestApp;
 use reqwest::StatusCode;
+use routini::application::StrategyKind;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
 #[tokio::test]
 async fn should_distribute_requests_evenly_among_backends() {
-    let app = match TestApp::new().await {
+    let app = match TestApp::new(StrategyKind::RoundRobin).await {
         Ok(app) => app,
         Err(err) => {
             eprintln!("Skipping test: unable to bootstrap test app ({err})");
@@ -39,7 +40,7 @@ async fn should_distribute_requests_evenly_among_backends() {
 
 #[tokio::test]
 async fn should_distribute_requests_evenly_with_concurrent_requests() {
-    let app = match TestApp::new().await {
+    let app = match TestApp::new(StrategyKind::RoundRobin).await {
         Ok(app) => Arc::new(app),
         Err(err) => {
             eprintln!("Skipping test: unable to bootstrap test app ({err})");


### PR DESCRIPTION
Added an implementation for the least connections strategy.

### Overview
This is implemented by tracking the connections count through the `Tracing` Trait that lets us inject code when a connection is established and on disconnect. This means the logic for this strategy is not entirely contained in the struct representing the strategy. We have to implement tracing in the `HttpProxy` implementation.

### Behavior
A request will be sent to the backend with least active connections in it's pool, but this connection will be kept alive for reuse, if the same peer makes a new request, it will again be sent to the backend with active connections, even tho there is a pooled connection to the previous backend. When there are no parallel connections, it will look like this:

rq_1 to backend_1,
rq_2 to backend_2,
rq_3 to backend_3,
rq_4 to backend_1,
rq_5 to backend_1,
... now all requests go to backend_1 until there are more simultaneous connections.

The load balancer tracks number of connections in the pool, not connections in use.

### Request for feedback
- Naming,
- Anti patterns 
- Non idiomatic code

I am aware of the limitations of the behavior. Later I will be looking for a way to access pool information to assign requests to the backend with fewest connections in use.
