### PR TITLE
Path router

### DIFF
--- a/routini/Cargo.lock
+++ b/routini/Cargo.lock
@@ -374,6 +374,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "color-eyre"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,6 +547,16 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.1",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -1046,6 +1083,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1376,6 +1419,12 @@ name = "os_str_bytes"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+
+[[package]]
+name = "owo-colors"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
 
 [[package]]
 name = "parking_lot"
@@ -1824,9 +1873,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.3"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1836,9 +1885,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1933,6 +1982,7 @@ version = "0.1.0"
 dependencies = [
  "arc-swap",
  "async-trait",
+ "color-eyre",
  "derivative",
  "derive_more",
  "fake",
@@ -1945,6 +1995,7 @@ dependencies = [
  "pingora-ketama",
  "pingora-runtime",
  "rand 0.9.2",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",

--- a/routini/Cargo.lock
+++ b/routini/Cargo.lock
@@ -444,6 +444,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "deunicode"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1914,11 +1934,13 @@ dependencies = [
  "arc-swap",
  "async-trait",
  "derivative",
+ "derive_more",
  "fake",
  "fnv",
  "futures",
  "http",
  "log",
+ "matchit",
  "pingora",
  "pingora-ketama",
  "pingora-runtime",

--- a/routini/Cargo.toml
+++ b/routini/Cargo.toml
@@ -38,6 +38,8 @@ fnv = "1.0.7"
 serde = { version = "1.0.228", features = ["derive"] }
 http = "1.3.1"
 serde_json = "1.0.145"
+derive_more = { version = "2.0.1", features = ["from", "into"] }
+matchit = "0.8.4"
 
 
 [dev-dependencies]

--- a/routini/Cargo.toml
+++ b/routini/Cargo.toml
@@ -40,6 +40,8 @@ http = "1.3.1"
 serde_json = "1.0.145"
 derive_more = { version = "2.0.1", features = ["from", "into"] }
 matchit = "0.8.4"
+regex = "1.12.2"
+color-eyre = "0.6.5"
 
 
 [dev-dependencies]

--- a/routini/src/application.rs
+++ b/routini/src/application.rs
@@ -111,11 +111,12 @@ impl ApplicationBuilder {
                 let hc = TcpHealthCheck::new();
                 lb.set_health_check(hc);
             }
+
             let service_name = format!("lb updater-{}", &route.path);
             let background_service = background_service(&service_name, lb);
             let task = background_service.task();
-
             server.add_service(background_service);
+
             tracing::info!("Adding route: {}", route.path);
 
             let route_value = RouteValue {

--- a/routini/src/lib.rs
+++ b/routini/src/lib.rs
@@ -1,5 +1,5 @@
-pub mod application;
 pub mod load_balancing;
 pub mod proxy;
+pub mod server_builder;
 pub mod set_strategy_endpoint;
 pub mod utils;

--- a/routini/src/load_balancing/strategy/adaptive.rs
+++ b/routini/src/load_balancing/strategy/adaptive.rs
@@ -11,14 +11,14 @@ use crate::load_balancing::{
     },
 };
 
-#[derive(Default, PartialEq, Deserialize)]
+#[derive(Default, PartialEq, Deserialize, Clone)]
 pub enum Adaptive {
     #[default]
     RoundRobin,
     Random,
     FNVHash,
     Consistent,
-    LeastConnections,
+    FewestConnections,
 }
 
 impl Strategy for Adaptive {
@@ -38,7 +38,7 @@ impl Strategy for Adaptive {
             Adaptive::Consistent => {
                 AdaptiveSelector::Consistent(Arc::new(Consistent.build_backend_selector(backends)))
             }
-            Adaptive::LeastConnections => AdaptiveSelector::LeastConnections(Arc::new(
+            Adaptive::FewestConnections => AdaptiveSelector::LeastConnections(Arc::new(
                 FewestConnections.build_backend_selector(backends),
             )),
         }

--- a/routini/src/load_balancing/strategy/consistent.rs
+++ b/routini/src/load_balancing/strategy/consistent.rs
@@ -19,9 +19,10 @@ pub type ConsistentSelector = KetamaHashingSelector;
 use super::*;
 use pingora::protocols::l4::socket::SocketAddr;
 use pingora_ketama::{Bucket, Continuum};
+use serde::Deserialize;
 use std::collections::HashMap;
 
-#[derive(Default, PartialEq)]
+#[derive(Default, PartialEq, Deserialize)]
 pub struct Consistent;
 
 impl Strategy for Consistent {

--- a/routini/src/load_balancing/strategy/mod.rs
+++ b/routini/src/load_balancing/strategy/mod.rs
@@ -20,9 +20,7 @@ pub mod fewest_connections;
 pub mod fnv_hash;
 pub mod random;
 pub mod round_robin;
-// pub mod unique_iterator;
 pub mod utils;
-// pub mod weighted;
 
 pub use {
     adaptive::Adaptive, consistent::Consistent, fewest_connections::FewestConnections,
@@ -92,103 +90,3 @@ where
 }
 
 // TODO: least conn
-
-// /// An iterator which wraps another iterator and yields unique items. It optionally takes a max
-// /// number of iterations if the wrapped iterator never returns.
-// pub struct UniqueIterator<I>
-// where
-//     I: BackendIter,
-// {
-//     iter: I,
-//     seen: HashSet<u64>,
-//     max_iterations: usize,
-//     steps: usize,
-// }
-
-// impl<I> UniqueIterator<I>
-// where
-//     I: BackendIter,
-// {
-//     /// Wrap a new iterator and specify the maximum number of times we want to iterate.
-//     pub fn new(iter: I, max_iterations: usize) -> Self {
-//         Self {
-//             iter,
-//             max_iterations,
-//             seen: HashSet::new(),
-//             steps: 0,
-//         }
-//     }
-
-//     pub fn get_next(&mut self) -> Option<Backend> {
-//         while let Some(item) = self.iter.next() {
-//             if self.steps >= self.max_iterations {
-//                 return None;
-//             }
-//             self.steps += 1;
-
-//             let hash_key = item.hash_key();
-//             if !self.seen.contains(&hash_key) {
-//                 self.seen.insert(hash_key);
-//                 return Some(item.clone());
-//             }
-//         }
-
-//         None
-//     }
-// }
-
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
-
-//     struct TestIter {
-//         seq: Vec<Backend>,
-//         idx: usize,
-//     }
-//     impl TestIter {
-//         fn new(input: &[&Backend]) -> Self {
-//             Self {
-//                 seq: input.iter().cloned().cloned().collect(),
-//                 idx: 0,
-//             }
-//         }
-//     }
-//     impl BackendIter for TestIter {
-//         fn next(&mut self) -> Option<&Backend> {
-//             let idx = self.idx;
-//             self.idx += 1;
-//             self.seq.get(idx)
-//         }
-//     }
-
-//     #[test]
-//     fn unique_iter_max_iterations_is_correct() {
-//         let b1 = Backend::new("1.1.1.1:80").unwrap();
-//         let b2 = Backend::new("1.0.0.1:80").unwrap();
-//         let b3 = Backend::new("1.0.0.255:80").unwrap();
-//         let items = [&b1, &b2, &b3];
-
-//         let mut all = UniqueIterator::new(TestIter::new(&items), 3);
-//         assert_eq!(all.get_next(), Some(b1.clone()));
-//         assert_eq!(all.get_next(), Some(b2.clone()));
-//         assert_eq!(all.get_next(), Some(b3.clone()));
-//         assert_eq!(all.get_next(), None);
-
-//         let mut stop = UniqueIterator::new(TestIter::new(&items), 1);
-//         assert_eq!(stop.get_next(), Some(b1));
-//         assert_eq!(stop.get_next(), None);
-//     }
-
-//     #[test]
-//     fn unique_iter_duplicate_items_are_filtered() {
-//         let b1 = Backend::new("1.1.1.1:80").unwrap();
-//         let b2 = Backend::new("1.0.0.1:80").unwrap();
-//         let b3 = Backend::new("1.0.0.255:80").unwrap();
-//         let items = [&b1, &b1, &b2, &b2, &b2, &b3];
-
-//         let mut uniq = UniqueIterator::new(TestIter::new(&items), 10);
-//         assert_eq!(uniq.get_next(), Some(b1));
-//         assert_eq!(uniq.get_next(), Some(b2));
-//         assert_eq!(uniq.get_next(), Some(b3));
-//     }
-// }

--- a/routini/src/main.rs
+++ b/routini/src/main.rs
@@ -18,7 +18,7 @@ fn main() {
         "127.0.0.1:4002".to_owned(),
     ];
     let route = Route::new(
-        "/auth{*rest}",
+        "/auth/{*rest}",
         backends,
         Adaptive::RoundRobin,
         true,

--- a/routini/src/main.rs
+++ b/routini/src/main.rs
@@ -18,7 +18,7 @@ fn main() {
         "127.0.0.1:4002".to_owned(),
     ];
     let route = Route::new(
-        "/{*rest}",
+        "/auth{*rest}",
         backends,
         Adaptive::RoundRobin,
         true,

--- a/routini/src/main.rs
+++ b/routini/src/main.rs
@@ -1,3 +1,4 @@
+use color_eyre::eyre::Result;
 use routini::{
     load_balancing::strategy::Adaptive,
     server_builder::{Route, RouteConfig, proxy_server},
@@ -8,17 +9,18 @@ use routini::{
 };
 use std::net::TcpListener;
 
-fn main() {
-    init_tracing().expect("Failed to initialize tracing");
+fn main() -> Result<()> {
+    init_tracing().expect("Failed to set up tracing");
+    color_eyre::install().expect("Failed to install color_eyre");
 
-    let listener = TcpListener::bind("127.0.0.1:3500").expect("Failed to bind to address");
+    let listener = TcpListener::bind("127.0.0.1:3500")?;
     let backends = [
         "127.0.0.1:4000".to_owned(),
         "127.0.0.1:4001".to_owned(),
         "127.0.0.1:4002".to_owned(),
     ];
     let route = Route::new(
-        "/auth/{*rest}",
+        "/auth/*",
         backends,
         Adaptive::RoundRobin,
         true,
@@ -26,7 +28,7 @@ fn main() {
         RouteConfig {
             strip_path_prefix: true,
         },
-    );
+    )?;
 
     proxy_server(listener)
         .add_route(route)

--- a/routini/src/main.rs
+++ b/routini/src/main.rs
@@ -1,11 +1,8 @@
 use color_eyre::eyre::Result;
 use routini::{
     load_balancing::strategy::Adaptive,
-    server_builder::{Route, RouteConfig, proxy_server},
-    utils::{
-        constants::{DEFAULT_MAX_ALGORITHM_ITERATIONS, SET_STRATEGY_ENDPOINT_ADDRESS},
-        tracing::init_tracing,
-    },
+    server_builder::{Route, proxy_server},
+    utils::{constants::SET_STRATEGY_ENDPOINT_ADDRESS, tracing::init_tracing},
 };
 use std::net::TcpListener;
 
@@ -19,16 +16,7 @@ fn main() -> Result<()> {
         "127.0.0.1:4001".to_owned(),
         "127.0.0.1:4002".to_owned(),
     ];
-    let route = Route::new(
-        "/auth/*",
-        backends,
-        Adaptive::RoundRobin,
-        true,
-        DEFAULT_MAX_ALGORITHM_ITERATIONS,
-        RouteConfig {
-            strip_path_prefix: true,
-        },
-    )?;
+    let route = Route::new("/auth/*", backends, Adaptive::RoundRobin)?;
 
     proxy_server(listener)
         .add_route(route)

--- a/routini/src/main.rs
+++ b/routini/src/main.rs
@@ -1,6 +1,6 @@
 use routini::{
-    application::{Route, RouteConfig, application},
     load_balancing::strategy::Adaptive,
+    server_builder::{Route, RouteConfig, proxy_server},
     utils::{
         constants::{DEFAULT_MAX_ALGORITHM_ITERATIONS, SET_STRATEGY_ENDPOINT_ADDRESS},
         tracing::init_tracing,
@@ -28,7 +28,7 @@ fn main() {
         },
     );
 
-    application(listener)
+    proxy_server(listener)
         .add_route(route)
         .set_strategy_endpoint(SET_STRATEGY_ENDPOINT_ADDRESS.to_string())
         .build()

--- a/routini/src/proxy.rs
+++ b/routini/src/proxy.rs
@@ -89,7 +89,10 @@ impl ProxyHttp for Proxy {
                 retry: RetryType::Decided(true),
             })?;
 
-        if let Some(path) = new_path {
+        if let Some(mut path) = new_path {
+            if !path.starts_with('/') {
+                path.insert(0, '/');
+            }
             session.req_header_mut().set_raw_path(path.as_bytes())?;
         }
 
@@ -97,5 +100,186 @@ impl ProxyHttp for Proxy {
         let mut peer = Box::new(HttpPeer::new(backend, false, String::new()));
         peer.options.tracer = Some(tracer);
         Ok(peer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::load_balancing::strategy::Adaptive;
+
+    fn create_test_route_value(strip_path: bool) -> RouteValue {
+        let backends = vec!["127.0.0.1:8080".to_string()];
+        let lb = LoadBalancer::try_from_iter_with_strategy(backends, Adaptive::default())
+            .expect("Failed to create load balancer");
+
+        RouteValue {
+            lb: Arc::new(lb),
+            max_iterations: 10,
+            route_config: RouteConfig {
+                strip_path_prefix: strip_path,
+            },
+        }
+    }
+
+    #[test]
+    fn test_route_basic_matching() {
+        let mut router = Router::new();
+        router
+            .insert("/api", create_test_route_value(false))
+            .expect("Failed to insert route");
+
+        let proxy = Proxy::new(router);
+        let result = proxy.route("/api");
+
+        assert!(result.is_ok());
+        let (route_value, stripped_path) = result.unwrap();
+        assert_eq!(route_value.max_iterations, 10);
+        assert_eq!(stripped_path, None);
+    }
+
+    #[test]
+    fn test_route_with_wildcard() {
+        let mut router = Router::new();
+        router
+            .insert("/api/{*rest}", create_test_route_value(false))
+            .expect("Failed to insert route");
+
+        let proxy = Proxy::new(router);
+        let result = proxy.route("/api/users/123");
+
+        assert!(result.is_ok());
+        let (route_value, stripped_path) = result.unwrap();
+        assert_eq!(route_value.max_iterations, 10);
+        assert_eq!(stripped_path, None);
+    }
+
+    #[test]
+    fn test_route_with_path_stripping() {
+        let mut router = Router::new();
+        router
+            .insert("/auth/{*rest}", create_test_route_value(true))
+            .expect("Failed to insert route");
+
+        let proxy = Proxy::new(router);
+        let result = proxy.route("/auth/login");
+
+        assert!(result.is_ok());
+        let (route_value, stripped_path) = result.unwrap();
+        assert!(route_value.route_config.strip_path_prefix);
+        assert_eq!(stripped_path, Some("login".to_string()));
+    }
+
+    #[test]
+    fn test_route_with_path_stripping_nested() {
+        let mut router = Router::new();
+        router
+            .insert("/api/v1/{*rest}", create_test_route_value(true))
+            .expect("Failed to insert route");
+
+        let proxy = Proxy::new(router);
+        let result = proxy.route("/api/v1/users/123/profile");
+
+        assert!(result.is_ok());
+        let (route_value, stripped_path) = result.unwrap();
+        assert!(route_value.route_config.strip_path_prefix);
+        assert_eq!(stripped_path, Some("users/123/profile".to_string()));
+    }
+
+    #[test]
+    fn test_route_not_found() {
+        let mut router = Router::new();
+        router
+            .insert("/api", create_test_route_value(false))
+            .expect("Failed to insert route");
+
+        let proxy = Proxy::new(router);
+        let result = proxy.route("/nonexistent");
+
+        assert!(result.is_err());
+        if let Err(err) = result {
+            assert_eq!(
+                err.etype,
+                ErrorType::HTTPStatus(StatusCode::BAD_REQUEST.as_u16())
+            );
+        }
+    }
+
+    #[test]
+    fn test_route_multiple_routes() {
+        let mut router = Router::new();
+        router
+            .insert("/api", create_test_route_value(false))
+            .expect("Failed to insert route");
+        router
+            .insert("/auth/{*rest}", create_test_route_value(true))
+            .expect("Failed to insert route");
+
+        let proxy = Proxy::new(router);
+
+        let result = proxy.route("/api");
+        assert!(result.is_ok());
+        let (_, stripped) = result.unwrap();
+        assert_eq!(stripped, None);
+
+        let result = proxy.route("/auth/logout");
+        assert!(result.is_ok());
+        let (route_value, stripped) = result.unwrap();
+        assert!(route_value.route_config.strip_path_prefix);
+        assert_eq!(stripped, Some("logout".to_string()));
+    }
+
+    #[test]
+    fn test_route_exact_vs_wildcard_priority() {
+        let mut router = Router::new();
+        let mut exact_route = create_test_route_value(false);
+        exact_route.max_iterations = 5;
+
+        router
+            .insert("/api/health", exact_route)
+            .expect("Failed to insert exact route");
+        router
+            .insert("/api/{*rest}", create_test_route_value(false))
+            .expect("Failed to insert wildcard route");
+
+        let proxy = Proxy::new(router);
+
+        let result = proxy.route("/api/health");
+        assert!(result.is_ok());
+        let (route_value, _) = result.unwrap();
+        assert_eq!(route_value.max_iterations, 5);
+
+        let result = proxy.route("/api/users");
+        assert!(result.is_ok());
+        let (route_value, _) = result.unwrap();
+        assert_eq!(route_value.max_iterations, 10);
+    }
+
+    #[test]
+    fn test_route_empty_path() {
+        let mut router = Router::new();
+        router
+            .insert("/", create_test_route_value(false))
+            .expect("Failed to insert route");
+
+        let proxy = Proxy::new(router);
+        let result = proxy.route("/");
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_route_with_query_params() {
+        let mut router = Router::new();
+        router
+            .insert("/search/{*rest}", create_test_route_value(true))
+            .expect("Failed to insert route");
+
+        let proxy = Proxy::new(router);
+        let result = proxy.route("/search/query?q=test");
+
+        assert!(result.is_ok());
+        let (_, stripped_path) = result.unwrap();
+        assert_eq!(stripped_path, Some("query?q=test".to_string()));
     }
 }

--- a/routini/src/proxy.rs
+++ b/routini/src/proxy.rs
@@ -170,7 +170,7 @@ mod tests {
         assert!(result.is_ok());
         let (route_value, stripped_path) = result.unwrap();
         assert!(route_value.route_config.strip_path_prefix);
-        assert_eq!(stripped_path, Some("login".to_string()));
+        assert_eq!(stripped_path, Some("/login".to_string()));
     }
 
     #[test]
@@ -186,7 +186,7 @@ mod tests {
         assert!(result.is_ok());
         let (route_value, stripped_path) = result.unwrap();
         assert!(route_value.route_config.strip_path_prefix);
-        assert_eq!(stripped_path, Some("users/123/profile".to_string()));
+        assert_eq!(stripped_path, Some("/users/123/profile".to_string()));
     }
 
     #[test]
@@ -229,7 +229,7 @@ mod tests {
         assert!(result.is_ok());
         let (route_value, stripped) = result.unwrap();
         assert!(route_value.route_config.strip_path_prefix);
-        assert_eq!(stripped, Some("logout".to_string()));
+        assert_eq!(stripped, Some("/logout".to_string()));
     }
 
     #[test]
@@ -283,6 +283,6 @@ mod tests {
 
         assert!(result.is_ok());
         let (_, stripped_path) = result.unwrap();
-        assert_eq!(stripped_path, Some("query?q=test".to_string()));
+        assert_eq!(stripped_path, Some("/query?q=test".to_string()));
     }
 }

--- a/routini/src/proxy.rs
+++ b/routini/src/proxy.rs
@@ -53,7 +53,7 @@ impl Proxy {
             .map(|m| {
                 let value = m.value;
                 let stripped_path = if value.route_config.strip_path_prefix {
-                    m.params.get("rest").map(|s| format!("/{}", s))
+                    m.params.get("rest").map(|p| p.to_string())
                 } else {
                     None
                 };
@@ -97,12 +97,5 @@ impl ProxyHttp for Proxy {
         let mut peer = Box::new(HttpPeer::new(backend, false, String::new()));
         peer.options.tracer = Some(tracer);
         Ok(peer)
-    }
-
-    async fn request_filter(&self, _session: &mut Session, _ctx: &mut Self::CTX) -> Result<bool>
-    where
-        Self::CTX: Send + Sync,
-    {
-        Ok(false)
     }
 }

--- a/routini/src/proxy.rs
+++ b/routini/src/proxy.rs
@@ -10,11 +10,11 @@ use pingora::{
 };
 
 use crate::{
-    application::RouteConfig,
     load_balancing::{
         LoadBalancer,
         strategy::{Adaptive, fewest_connections::ConnectionsTracer},
     },
+    server_builder::RouteConfig,
 };
 
 type MaxIterations = usize;

--- a/routini/src/proxy.rs
+++ b/routini/src/proxy.rs
@@ -1,3 +1,5 @@
+use http::StatusCode;
+use matchit::Router;
 use std::sync::Arc;
 
 use pingora::{
@@ -6,36 +8,79 @@ use pingora::{
     proxy::{ProxyHttp, Session},
     upstreams::peer::Tracer,
 };
-use tracing::instrument;
 
-use crate::load_balancing::{
-    LoadBalancer,
-    strategy::{Strategy, fewest_connections::ConnectionsTracer},
+use crate::{
+    application::RouteConfig,
+    load_balancing::{
+        LoadBalancer,
+        strategy::{Adaptive, fewest_connections::ConnectionsTracer},
+    },
 };
 
-pub const DEFAULT_MAX_ALGORITHM_ITERATIONS: usize = 256;
+type MaxIterations = usize;
 
-pub struct LB<S: Strategy> {
-    pub load_balancer: Arc<LoadBalancer<S>>,
+pub struct RouteValue {
+    pub lb: Arc<LoadBalancer<Adaptive>>,
+    pub max_iterations: MaxIterations,
+    pub route_config: RouteConfig,
+}
+
+#[derive(Clone)]
+pub struct Proxy {
+    routes: Arc<Router<RouteValue>>,
+}
+
+impl Proxy {
+    pub fn new(routes: Router<RouteValue>) -> Self {
+        Proxy {
+            routes: Arc::new(routes),
+        }
+    }
+
+    pub fn route(&self, path: &str) -> Result<(&RouteValue, Option<String>)> {
+        tracing::info!("route path: {}", path);
+        self.routes
+            .at(path)
+            .map_err(|e| {
+                Box::new(Error {
+                    cause: Some(Box::new(e)),
+                    context: Some(ImmutStr::Static("Failed to route path to backend")),
+                    esource: ErrorSource::Internal,
+                    etype: ErrorType::HTTPStatus(StatusCode::BAD_REQUEST.as_u16()),
+                    retry: RetryType::Decided(false),
+                })
+            })
+            .map(|m| {
+                let value = m.value;
+                let stripped_path = if value.route_config.strip_path_prefix {
+                    m.params.get("rest").map(|s| format!("/{}", s))
+                } else {
+                    None
+                };
+                (value, stripped_path)
+            })
+    }
 }
 
 #[async_trait::async_trait]
-impl<S: Strategy> ProxyHttp for LB<S>
-where
-    S: Strategy,
-{
-    type CTX = ();
-    fn new_ctx(&self) -> Self::CTX {}
+impl ProxyHttp for Proxy {
+    type CTX = Option<String>;
 
-    #[instrument(skip_all, err(Debug))]
+    fn new_ctx(&self) -> Self::CTX {
+        None
+    }
+
     async fn upstream_peer(
         &self,
-        _session: &mut Session,
+        session: &mut Session,
         _ctx: &mut Self::CTX,
     ) -> Result<Box<HttpPeer>> {
-        let upstream = self
-            .load_balancer
-            .select(&[], DEFAULT_MAX_ALGORITHM_ITERATIONS)
+        let path = session.req_header().uri.path();
+        let (route_value, new_path) = self.route(path)?;
+
+        let backend = route_value
+            .lb
+            .select(&[], route_value.max_iterations)
             .ok_or(Error {
                 context: Some(ImmutStr::Static("No healthy backends available")),
                 cause: None,
@@ -44,9 +89,20 @@ where
                 retry: RetryType::Decided(true),
             })?;
 
-        let tracer = Tracer(Box::new(ConnectionsTracer(upstream.addr.clone())));
-        let mut peer = Box::new(HttpPeer::new(upstream, false, String::new()));
+        if let Some(path) = new_path {
+            session.req_header_mut().set_raw_path(path.as_bytes())?;
+        }
+
+        let tracer = Tracer(Box::new(ConnectionsTracer(backend.addr.clone())));
+        let mut peer = Box::new(HttpPeer::new(backend, false, String::new()));
         peer.options.tracer = Some(tracer);
         Ok(peer)
+    }
+
+    async fn request_filter(&self, _session: &mut Session, _ctx: &mut Self::CTX) -> Result<bool>
+    where
+        Self::CTX: Send + Sync,
+    {
+        Ok(false)
     }
 }

--- a/routini/src/proxy.rs
+++ b/routini/src/proxy.rs
@@ -53,7 +53,13 @@ impl Proxy {
             .map(|m| {
                 let value = m.value;
                 let stripped_path = if value.route_config.strip_path_prefix {
-                    m.params.get("rest").map(|p| p.to_string())
+                    m.params.get("rest").map(|p| {
+                        if !p.starts_with('/') {
+                            format!("/{p}")
+                        } else {
+                            p.to_string()
+                        }
+                    })
                 } else {
                     None
                 };
@@ -89,10 +95,7 @@ impl ProxyHttp for Proxy {
                 retry: RetryType::Decided(true),
             })?;
 
-        if let Some(mut path) = new_path {
-            if !path.starts_with('/') {
-                path.insert(0, '/');
-            }
+        if let Some(path) = new_path {
             session.req_header_mut().set_raw_path(path.as_bytes())?;
         }
 

--- a/routini/src/server_builder.rs
+++ b/routini/src/server_builder.rs
@@ -9,7 +9,7 @@ use crate::{
     load_balancing::{LoadBalancer, health_check::TcpHealthCheck, strategy::Adaptive},
     proxy::{Proxy, RouteValue},
     set_strategy_endpoint::SetStrategyEndpoint,
-    utils::constants::DEFAULT_MAX_ALGORITHM_ITERATIONS,
+    utils::constants::{DEFAULT_MAX_ALGORITHM_ITERATIONS, WILDCARD_IDENTIFIER},
 };
 
 const PATH_REGEX_PATTERN: &str = r"^/[^*]*\*?$";
@@ -68,7 +68,7 @@ impl Route {
                 "Invalid path, it must start with '/', have at most one * and any eventual * must be at the end of the string"
             ));
         }
-        let path = path.as_ref().replacen("*", "{*rest}", 1);
+        let path = path.as_ref().replacen("*", WILDCARD_IDENTIFIER, 1);
 
         let backends = backends
             .into_iter()

--- a/routini/src/set_strategy_endpoint.rs
+++ b/routini/src/set_strategy_endpoint.rs
@@ -62,14 +62,14 @@ impl ServeHttp for SetStrategyEndpoint {
                 };
                 let Some(body) = body else {
                     error!("Empty body");
-                    return response(StatusCode::INTERNAL_SERVER_ERROR);
+                    return response(StatusCode::BAD_REQUEST);
                 };
 
                 match serde_json::from_slice::<NewStrategy>(&body) {
                     Ok(NewStrategy { path, strategy }) => match self.router.route(&path) {
                         Ok((route_value, _)) => {
                             route_value.lb.update_strategy(strategy.clone());
-                            info!("Strategy updated to {}", strategy);
+                            info!("Strategy updated to {} for {}", strategy, path);
                             response(StatusCode::OK)
                         }
                         Err(err) => {

--- a/routini/src/utils/constants.rs
+++ b/routini/src/utils/constants.rs
@@ -1,2 +1,4 @@
 pub const SET_STRATEGY_ENDPOINT_NAME: &str = "strategy_updater";
 pub const SET_STRATEGY_ENDPOINT_ADDRESS: &str = "0.0.0.0:5000";
+
+pub const DEFAULT_MAX_ALGORITHM_ITERATIONS: usize = 256;

--- a/routini/src/utils/constants.rs
+++ b/routini/src/utils/constants.rs
@@ -2,3 +2,6 @@ pub const SET_STRATEGY_ENDPOINT_NAME: &str = "strategy_updater";
 pub const SET_STRATEGY_ENDPOINT_ADDRESS: &str = "0.0.0.0:5000";
 
 pub const DEFAULT_MAX_ALGORITHM_ITERATIONS: usize = 256;
+
+pub const PATH_REMAINDER_IDENTIFIER: &str = "rest";
+pub const WILDCARD_IDENTIFIER: &str = "{*rest}";

--- a/routini/tests/load_balancer/fewest_connections.rs
+++ b/routini/tests/load_balancer/fewest_connections.rs
@@ -1,13 +1,14 @@
 use crate::helpers::TestApp;
 use reqwest::StatusCode;
-use routini::load_balancing::strategy::fewest_connections::{CONNECTIONS, FewestConnections};
+use routini::load_balancing::strategy::Adaptive;
+use routini::load_balancing::strategy::fewest_connections::CONNECTIONS;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Mutex;
 
 #[tokio::test]
-async fn should_connect_to_backend_with_least_connections() {
-    let app = match TestApp::new(FewestConnections).await {
+async fn should_connect_to_backend_with_fewest_connections() {
+    let app = match TestApp::new(Adaptive::FewestConnections).await {
         Ok(app) => Arc::new(app),
         Err(err) => {
             eprintln!("Skipping test: unable to bootstrap test app ({err})");

--- a/routini/tests/load_balancer/helpers.rs
+++ b/routini/tests/load_balancer/helpers.rs
@@ -44,7 +44,8 @@ impl TestApp {
                 RouteConfig {
                     strip_path_prefix: false,
                 },
-            );
+            )
+            .expect("Failed to construct route");
 
             proxy_server(listener)
                 .add_route(route)

--- a/routini/tests/load_balancer/helpers.rs
+++ b/routini/tests/load_balancer/helpers.rs
@@ -2,8 +2,8 @@ use std::{io, net::Ipv4Addr};
 
 use fake::{Fake, Faker};
 use routini::{
-    application::{Route, RouteConfig, application},
     load_balancing::strategy::Adaptive,
+    server_builder::{Route, RouteConfig, proxy_server},
     utils::constants::DEFAULT_MAX_ALGORITHM_ITERATIONS,
 };
 use tokio::net::TcpListener;
@@ -46,7 +46,10 @@ impl TestApp {
                 },
             );
 
-            application(listener).add_route(route).build().run_forever()
+            proxy_server(listener)
+                .add_route(route)
+                .build()
+                .run_forever();
         });
 
         let http_client = reqwest::Client::builder()

--- a/routini/tests/load_balancer/helpers.rs
+++ b/routini/tests/load_balancer/helpers.rs
@@ -4,7 +4,6 @@ use fake::{Fake, Faker};
 use routini::{
     load_balancing::strategy::Adaptive,
     server_builder::{Route, RouteConfig, proxy_server},
-    utils::constants::DEFAULT_MAX_ALGORITHM_ITERATIONS,
 };
 use tokio::net::TcpListener;
 
@@ -35,17 +34,11 @@ impl TestApp {
 
         let backend_addr_clone = backend_addresses.clone();
         std::thread::spawn(move || {
-            let route = Route::new(
-                "/health",
-                backend_addr_clone,
-                selection_strategy,
-                true,
-                DEFAULT_MAX_ALGORITHM_ITERATIONS,
-                RouteConfig {
+            let route = Route::new("/health", backend_addr_clone, selection_strategy)
+                .expect("Failed to construct route")
+                .route_config(RouteConfig {
                     strip_path_prefix: false,
-                },
-            )
-            .expect("Failed to construct route");
+                });
 
             proxy_server(listener)
                 .add_route(route)

--- a/routini/tests/load_balancer/main.rs
+++ b/routini/tests/load_balancer/main.rs
@@ -1,3 +1,3 @@
+mod fewest_connections;
 mod helpers;
-mod least_connections;
 mod round_robin;

--- a/routini/tests/load_balancer/round_robin.rs
+++ b/routini/tests/load_balancer/round_robin.rs
@@ -1,12 +1,12 @@
 use crate::helpers::TestApp;
 use reqwest::StatusCode;
-use routini::load_balancing::strategy::round_robin::RoundRobin;
+use routini::load_balancing::strategy::Adaptive;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
 #[tokio::test]
 async fn should_distribute_requests_evenly_among_backends() {
-    let app = match TestApp::new(RoundRobin).await {
+    let app = match TestApp::new(Adaptive::RoundRobin).await {
         Ok(app) => app,
         Err(err) => {
             eprintln!("Skipping test: unable to bootstrap test app ({err})");
@@ -40,7 +40,7 @@ async fn should_distribute_requests_evenly_among_backends() {
 
 #[tokio::test]
 async fn should_distribute_requests_evenly_with_concurrent_requests() {
-    let app = match TestApp::new(RoundRobin::default()).await {
+    let app = match TestApp::new(Adaptive::RoundRobin).await {
         Ok(app) => Arc::new(app),
         Err(err) => {
             eprintln!("Skipping test: unable to bootstrap test app ({err})");

--- a/routini/tests/proxy/helpers.rs
+++ b/routini/tests/proxy/helpers.rs
@@ -1,0 +1,61 @@
+use routini::server_builder::{Route, proxy_server};
+use std::io;
+use tokio::net::TcpListener;
+
+pub struct TestApp {
+    pub server_address: String,
+    pub http_client: reqwest::Client,
+}
+
+impl TestApp {
+    /// Creates a new test proxy server with the given routes.
+    ///
+    /// If `num_backends` is provided, it will spawn that many backend servers
+    /// and return their addresses for use in route configuration.
+    pub async fn new(routes: Vec<Route>) -> io::Result<Self> {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
+        let server_address = format!("http://{}", listener.local_addr()?);
+
+        std::thread::spawn(move || {
+            let mut server_builder = proxy_server(listener);
+            for route in routes {
+                server_builder = server_builder.add_route(route);
+            }
+            server_builder.build().run_forever();
+        });
+
+        let http_client = reqwest::Client::builder()
+            .build()
+            .expect("Failed to build http client");
+
+        // Give the server a moment to start
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        Ok(Self {
+            server_address,
+            http_client,
+        })
+    }
+
+    /// Creates backend servers and returns their addresses
+    pub async fn create_backends(num_backends: usize) -> io::Result<Vec<String>> {
+        let mut backend_listeners = Vec::new();
+        for _ in 0..num_backends {
+            backend_listeners.push(TcpListener::bind("127.0.0.1:0").await?);
+        }
+
+        let backend_addresses: Vec<String> = backend_listeners
+            .iter()
+            .map(|l| l.local_addr().map(|addr| addr.to_string()))
+            .collect::<io::Result<Vec<_>>>()?;
+
+        tokio::spawn(async move {
+            workers::Workers::run(backend_listeners).await;
+        });
+
+        // Give backends time to start
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        Ok(backend_addresses)
+    }
+}

--- a/routini/tests/proxy/main.rs
+++ b/routini/tests/proxy/main.rs
@@ -1,0 +1,2 @@
+mod helpers;
+mod upstream_peer;

--- a/routini/tests/proxy/upstream_peer.rs
+++ b/routini/tests/proxy/upstream_peer.rs
@@ -1,0 +1,172 @@
+use reqwest::StatusCode;
+use routini::{
+    load_balancing::strategy::Adaptive,
+    server_builder::{Route, RouteConfig},
+    utils::constants::DEFAULT_MAX_ALGORITHM_ITERATIONS,
+};
+
+use super::helpers::TestApp;
+
+/// Tests that a request to a non-existent route returns BAD_REQUEST
+#[tokio::test]
+async fn test_upstream_peer_not_found_route() {
+    let backends = vec!["127.0.0.1:8001".to_string()];
+    let route = Route::new(
+        "/api",
+        backends,
+        Adaptive::default(),
+        false,
+        DEFAULT_MAX_ALGORITHM_ITERATIONS,
+        RouteConfig {
+            strip_path_prefix: false,
+        },
+    );
+
+    let app = TestApp::new(vec![route]).await.unwrap();
+
+    let response = app
+        .http_client
+        .get(format!("{}/nonexistent", app.server_address))
+        .send()
+        .await
+        .expect("Failed to send request");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+/// Tests that routing works with actual backend servers
+#[tokio::test]
+async fn test_upstream_peer_with_real_backends() {
+    let backend_addresses = TestApp::create_backends(2).await.unwrap();
+
+    let route = Route::new(
+        "/health",
+        backend_addresses,
+        Adaptive::default(),
+        false,
+        DEFAULT_MAX_ALGORITHM_ITERATIONS,
+        RouteConfig {
+            strip_path_prefix: false,
+        },
+    );
+
+    let app = TestApp::new(vec![route]).await.unwrap();
+
+    let response = app
+        .http_client
+        .get(format!("{}/health", app.server_address))
+        .send()
+        .await
+        .expect("Failed to send request");
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+/// Tests that path stripping works correctly
+#[tokio::test]
+async fn test_upstream_peer_path_stripping() {
+    let backend_addresses = TestApp::create_backends(1).await.unwrap();
+
+    let route = Route::new(
+        "/api/{*rest}",
+        backend_addresses,
+        Adaptive::default(),
+        false,
+        DEFAULT_MAX_ALGORITHM_ITERATIONS,
+        RouteConfig {
+            strip_path_prefix: true,
+        },
+    );
+
+    let app = TestApp::new(vec![route]).await.unwrap();
+
+    // Request /api/health - should strip /api and send /health to backend
+    let response = app
+        .http_client
+        .get(format!("{}/api/health", app.server_address))
+        .send()
+        .await
+        .expect("Failed to send request");
+
+    // Backend should receive request with path /health (stripped /api prefix)
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+/// Tests multiple routes with different configurations
+#[tokio::test]
+async fn test_upstream_peer_multiple_routes() {
+    let backend_addresses = TestApp::create_backends(2).await.unwrap();
+    let addr1 = backend_addresses[0].clone();
+    let addr2 = backend_addresses[1].clone();
+
+    let route1 = Route::new(
+        "/work",
+        vec![addr1],
+        Adaptive::default(),
+        false,
+        DEFAULT_MAX_ALGORITHM_ITERATIONS,
+        RouteConfig {
+            strip_path_prefix: false,
+        },
+    );
+
+    let route2 = Route::new(
+        "/api/{*rest}",
+        vec![addr2],
+        Adaptive::default(),
+        false,
+        DEFAULT_MAX_ALGORITHM_ITERATIONS,
+        RouteConfig {
+            strip_path_prefix: true,
+        },
+    );
+
+    let app = TestApp::new(vec![route1, route2]).await.unwrap();
+
+    let response1 = app
+        .http_client
+        .get(format!("{}/work", app.server_address))
+        .send()
+        .await
+        .expect("Failed to send request");
+    assert_eq!(response1.status(), StatusCode::OK);
+
+    let response2 = app
+        .http_client
+        .get(format!("{}/api/health", app.server_address))
+        .send()
+        .await
+        .expect("Failed to send request");
+    assert_eq!(response2.status(), StatusCode::OK);
+}
+
+/// Tests load balancing across multiple backends
+#[tokio::test]
+async fn test_upstream_peer_load_balancing() {
+    let backend_addresses = TestApp::create_backends(3).await.unwrap();
+
+    let route = Route::new(
+        "/work",
+        backend_addresses,
+        Adaptive::default(),
+        false,
+        DEFAULT_MAX_ALGORITHM_ITERATIONS,
+        RouteConfig {
+            strip_path_prefix: false,
+        },
+    );
+
+    let app = TestApp::new(vec![route]).await.unwrap();
+
+    // Make multiple requests to test load balancing
+    for _ in 0..5 {
+        let response = app
+            .http_client
+            .get(format!("{}/work", app.server_address))
+            .send()
+            .await
+            .expect("Failed to send request");
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+}

--- a/routini/tests/proxy/upstream_peer.rs
+++ b/routini/tests/proxy/upstream_peer.rs
@@ -6,7 +6,7 @@ use routini::{
 
 use super::helpers::TestApp;
 
-/// Tests that a request to a non-existent route returns BAD_REQUEST
+/// Tests that a request to a non-existent route returns NOT_FOUND
 #[tokio::test]
 async fn test_upstream_peer_not_found_route() {
     let backends = vec!["127.0.0.1:8001".to_string()];

--- a/routini/tests/proxy/upstream_peer.rs
+++ b/routini/tests/proxy/upstream_peer.rs
@@ -2,7 +2,6 @@ use reqwest::StatusCode;
 use routini::{
     load_balancing::strategy::Adaptive,
     server_builder::{Route, RouteConfig},
-    utils::constants::DEFAULT_MAX_ALGORITHM_ITERATIONS,
 };
 
 use super::helpers::TestApp;
@@ -11,17 +10,12 @@ use super::helpers::TestApp;
 #[tokio::test]
 async fn test_upstream_peer_not_found_route() {
     let backends = vec!["127.0.0.1:8001".to_string()];
-    let route = Route::new(
-        "/api",
-        backends,
-        Adaptive::default(),
-        false,
-        DEFAULT_MAX_ALGORITHM_ITERATIONS,
-        RouteConfig {
+    let route = Route::new("/api", backends, Adaptive::default())
+        .expect("Invalid route")
+        .include_health_check(false)
+        .route_config(RouteConfig {
             strip_path_prefix: false,
-        },
-    )
-    .expect("Invalid route");
+        });
 
     let app = TestApp::new(vec![route]).await.unwrap();
 
@@ -40,17 +34,12 @@ async fn test_upstream_peer_not_found_route() {
 async fn test_upstream_peer_with_real_backends() {
     let backend_addresses = TestApp::create_backends(2).await.unwrap();
 
-    let route = Route::new(
-        "/health",
-        backend_addresses,
-        Adaptive::default(),
-        false,
-        DEFAULT_MAX_ALGORITHM_ITERATIONS,
-        RouteConfig {
+    let route = Route::new("/health", backend_addresses, Adaptive::default())
+        .expect("Invalid route")
+        .include_health_check(false)
+        .route_config(RouteConfig {
             strip_path_prefix: false,
-        },
-    )
-    .expect("Invalid route");
+        });
 
     let app = TestApp::new(vec![route]).await.unwrap();
 
@@ -69,17 +58,9 @@ async fn test_upstream_peer_with_real_backends() {
 async fn test_upstream_peer_path_stripping() {
     let backend_addresses = TestApp::create_backends(1).await.unwrap();
 
-    let route = Route::new(
-        "/api/*",
-        backend_addresses,
-        Adaptive::default(),
-        false,
-        DEFAULT_MAX_ALGORITHM_ITERATIONS,
-        RouteConfig {
-            strip_path_prefix: true,
-        },
-    )
-    .expect("Invalid route");
+    let route = Route::new("/api/*", backend_addresses, Adaptive::default())
+        .expect("Invalid route")
+        .include_health_check(false);
 
     let app = TestApp::new(vec![route]).await.unwrap();
 
@@ -102,29 +83,13 @@ async fn test_upstream_peer_multiple_routes() {
     let addr1 = backend_addresses[0].clone();
     let addr2 = backend_addresses[1].clone();
 
-    let route1 = Route::new(
-        "/work",
-        vec![addr1],
-        Adaptive::default(),
-        false,
-        DEFAULT_MAX_ALGORITHM_ITERATIONS,
-        RouteConfig {
-            strip_path_prefix: false,
-        },
-    )
-    .expect("Invalid route");
+    let route1 = Route::new("/work", vec![addr1], Adaptive::default())
+        .expect("Invalid route")
+        .include_health_check(false);
 
-    let route2 = Route::new(
-        "/api/*",
-        vec![addr2],
-        Adaptive::default(),
-        false,
-        DEFAULT_MAX_ALGORITHM_ITERATIONS,
-        RouteConfig {
-            strip_path_prefix: true,
-        },
-    )
-    .expect("Invalid route");
+    let route2 = Route::new("/api/*", vec![addr2], Adaptive::default())
+        .expect("Invalid route")
+        .include_health_check(false);
 
     let app = TestApp::new(vec![route1, route2]).await.unwrap();
 
@@ -150,17 +115,12 @@ async fn test_upstream_peer_multiple_routes() {
 async fn test_upstream_peer_load_balancing() {
     let backend_addresses = TestApp::create_backends(3).await.unwrap();
 
-    let route = Route::new(
-        "/work",
-        backend_addresses,
-        Adaptive::default(),
-        false,
-        DEFAULT_MAX_ALGORITHM_ITERATIONS,
-        RouteConfig {
+    let route = Route::new("/work", backend_addresses, Adaptive::default())
+        .expect("Invalid route")
+        .include_health_check(false)
+        .route_config(RouteConfig {
             strip_path_prefix: false,
-        },
-    )
-    .expect("Invalid route");
+        });
 
     let app = TestApp::new(vec![route]).await.unwrap();
 

--- a/routini/tests/proxy/upstream_peer.rs
+++ b/routini/tests/proxy/upstream_peer.rs
@@ -26,7 +26,7 @@ async fn test_upstream_peer_not_found_route() {
         .await
         .expect("Failed to send request");
 
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 /// Tests that routing works with actual backend servers

--- a/routini/tests/proxy/upstream_peer.rs
+++ b/routini/tests/proxy/upstream_peer.rs
@@ -20,7 +20,8 @@ async fn test_upstream_peer_not_found_route() {
         RouteConfig {
             strip_path_prefix: false,
         },
-    );
+    )
+    .expect("Invalid route");
 
     let app = TestApp::new(vec![route]).await.unwrap();
 
@@ -48,7 +49,8 @@ async fn test_upstream_peer_with_real_backends() {
         RouteConfig {
             strip_path_prefix: false,
         },
-    );
+    )
+    .expect("Invalid route");
 
     let app = TestApp::new(vec![route]).await.unwrap();
 
@@ -68,7 +70,7 @@ async fn test_upstream_peer_path_stripping() {
     let backend_addresses = TestApp::create_backends(1).await.unwrap();
 
     let route = Route::new(
-        "/api/{*rest}",
+        "/api/*",
         backend_addresses,
         Adaptive::default(),
         false,
@@ -76,7 +78,8 @@ async fn test_upstream_peer_path_stripping() {
         RouteConfig {
             strip_path_prefix: true,
         },
-    );
+    )
+    .expect("Invalid route");
 
     let app = TestApp::new(vec![route]).await.unwrap();
 
@@ -108,10 +111,11 @@ async fn test_upstream_peer_multiple_routes() {
         RouteConfig {
             strip_path_prefix: false,
         },
-    );
+    )
+    .expect("Invalid route");
 
     let route2 = Route::new(
-        "/api/{*rest}",
+        "/api/*",
         vec![addr2],
         Adaptive::default(),
         false,
@@ -119,7 +123,8 @@ async fn test_upstream_peer_multiple_routes() {
         RouteConfig {
             strip_path_prefix: true,
         },
-    );
+    )
+    .expect("Invalid route");
 
     let app = TestApp::new(vec![route1, route2]).await.unwrap();
 
@@ -154,7 +159,8 @@ async fn test_upstream_peer_load_balancing() {
         RouteConfig {
             strip_path_prefix: false,
         },
-    );
+    )
+    .expect("Invalid route");
 
     let app = TestApp::new(vec![route]).await.unwrap();
 


### PR DESCRIPTION
### Overview
This PR introduces path-based routing capabilities, allowing different routes to be proxied to different backend collections, each with their own load balancing strategy and configuration.

### What Changed

#### Core Features

**1. Path-Based Routing (`src/proxy.rs`)**
- Added `Proxy` struct that uses [`matchit`](https://github.com/ibraheemdev/matchit) for efficient path routing
- Each route maps to a dedicated `LoadBalancer` instance with independent configuration
- Support for wildcard routes with transformation: `/example/*`
- Optional path prefix stripping for clean backend request paths

**2. Path Validation and Transformation**
- Validates that paths start with `/`
- Validates that `*` wildcard (if present) appears only once at the end

**3. Route Configuration (`src/server_builder.rs`)**
- New `RouteConfig` struct with configurable path stripping behavior
- `Route` builder API for defining backend collections per route
- Support for per-route load balancing strategies, health checks, and iteration limits
- Routes are built into separate background services for independent lifecycle management


### Request for feedback
- Module structure
- Non idiomatic patterns?
